### PR TITLE
データ追加時に必要なcolumnのnullデータをサーバ側で用意するよう変更

### DIFF
--- a/next/src/components/table/Row.tsx
+++ b/next/src/components/table/Row.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 
 import type {
   Data,
+  Column,
   ColumnGroup,
 } from '@/types';
 
@@ -15,12 +16,14 @@ import { useData } from '@/hooks/useData';
 
 
 type RowProps = {
+  columns: Column[];
   row: TanstackRow<Data>;
   followingColumnGroups: ColumnGroup[];
   addData: (args: Omit<Data, 'id'>) => Promise<void>;
 }
 
 const Row = ({
+  columns,
   row,
   followingColumnGroups,
   addData,
@@ -59,9 +62,6 @@ const Row = ({
         </td>
       )}
       <td className='border border-gray-300' >
-        {/* 削除ボタン */}
-        {/*
-        */}
         <RowDropdown
           projectId={projectId}
           dataId={row.original.id}
@@ -73,7 +73,8 @@ const Row = ({
           addData={async params => await addData({
             ...params,
             parentId: row.original.id,
-            projectId, data: {},
+            projectId, 
+            data: {},
           })}
         />
       </td>

--- a/next/src/components/table/Table.tsx
+++ b/next/src/components/table/Table.tsx
@@ -111,6 +111,7 @@ const Table = ({
           {table.getRowModel().rows.map(row =>
             <Row
               key={row.original.id}
+              columns={columns}
               row={row}
               followingColumnGroups={followingColumnGroups}
               addData={addData}

--- a/next/src/components/table/TableGroup.tsx
+++ b/next/src/components/table/TableGroup.tsx
@@ -107,10 +107,9 @@ const TableGroup = ({
         ? data[0]?.parentId ?? null 
         : null,
       // TODO データ追加について要件等、undefinedデータは-表示される
-      data: Object.fromEntries(
-        columns.map(c => [c.name, null])
-      ),
-    })
+      data: {},
+    });
+    console.log(`handleAddData called!`);
   };
                  
   return (


### PR DESCRIPTION
Data.data は任意のキーを持つJSON型になっており、MergedTableの場合には存在しないキーのデータを読み取る必要がある。

このとき、undefined（エントリが存在しない）ならば本当にこのエントリが存在しないと判断して
マイナスマークをセルに表示し、

null であれば明示的に空欄が指定されていると判断して、UIに入力欄を表示する

なので、これまで素朴に実装していた data: {} を書き込む方法ではエントリが一つもない状態になってしまい、全てのエントリがマイナスマークで表示されてしまっていた。

クライアント側で必要なcolumnsの情報を取得してserver側でもチェックを行うのでなく、
server側で必要なcolumnをnull値で追加することにした
以下の処理も行う
- data に値が指定されていればそれを優先して使用
- Dataに不適切なキーが含まれていれば例外
