### PR TITLE
250512 add flowid reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,9 @@ followingColumnGroupsの計算ではそうはいかないかもしれないの�
 flowStepColumnGroupsの編集時にfollowingColumnGroupsのonUpdateを呼びたいが、
 flowIdを指定する必要がある
 
-この方法だと意外なエラーが出る場合がある
-- flowStepColumnGroupを削除
-- server起動時に登録したイベントハンドラが、削除されたflowStepColumnGroupの
-  flowIdを参照しようとする
-- 見つからないためflowIdが分からず、どのflowにイベント発行すればよいか分からない
-- イベントハンドラ内で例外を出すとサーバが落ちる
-
-対策の例
-- イベントハンドラ内では例外をきちんと扱う
-- 削除をタイムスタンプ方式のソフトデリートにして、削除済みデータにアクセスする
-- flowStepColumnGroupsにflowIdも持たせる
+flowStepColumnGroupsにflowIdも持たせるのが最もスムーズで影響範囲が狭そう。
+これまで1世代以上前の親の情報は冗長なので子に持たせない事を考えていたが、
+こういう場合もあるというのは教育的かもしれない。
 
 WRITING...
 

--- a/database-preparation/addTestData.ts
+++ b/database-preparation/addTestData.ts
@@ -108,6 +108,7 @@ await db.insert(flowSteps).values([
 
 await db.insert(flowStepColumnGroups).values([
   {
+    flowId: 1,
     flowStepId: 1,
     columnGroupId: 1,
     projectId: zeroId,
@@ -115,6 +116,7 @@ await db.insert(flowStepColumnGroups).values([
     sort: null,
   },
   {
+    flowId: 1,
     flowStepId: 2,
     columnGroupId: 2,
     projectId: zeroId,

--- a/database/db/schema.ts
+++ b/database/db/schema.ts
@@ -308,6 +308,12 @@ export const flowStepColumnGroups = mysqlTable(
         .notNull()
         .primaryKey(),
     projectId: projectIdReference,
+    flowId:
+      bigint('flow_id', { mode: 'number', unsigned: true })
+        .notNull()
+        .references(() => flows.id, {
+          onUpdate: 'cascade', onDelete: 'cascade',
+        }),
     flowStepId:
       bigint('flow_step_id', { mode: 'number', unsigned: true })
         .notNull()

--- a/next/src/components/flow/FlowStepColumnGroups.tsx
+++ b/next/src/components/flow/FlowStepColumnGroups.tsx
@@ -57,8 +57,9 @@ export const FlowStepColumnGroups = ({
           className='btn-success'
           onClick={async () => await add({
             projectId,
-            columnGroupId: defaultColumnGroupId,
+            flowId,
             flowStepId: id,
+            columnGroupId: defaultColumnGroupId,
             grouping: { type: 'parent' },
             sort: null,
           })}

--- a/next/src/hooks/useFlowStepColumnGroups.ts
+++ b/next/src/hooks/useFlowStepColumnGroups.ts
@@ -15,7 +15,7 @@ export type UseFlowStepColumnGroupsArgs =
 
 export const useFlowStepColumnGroups = ({
   projectId,
-  //flowId,
+  flowId,
   id: flowStepId,
 }: UseFlowStepColumnGroupsArgs) => {
   const target = trpc.flow.flowStepColumnGroup;
@@ -24,7 +24,7 @@ export const useFlowStepColumnGroups = ({
     isLoading,
   } = target.list.useQuery({
     projectId,
-    //flowId,
+    flowId,
     flowStepId
   });
   const [data, setData] = useState<FlowStepColumnGroup[]>([]);
@@ -43,16 +43,16 @@ export const useFlowStepColumnGroups = ({
     setData(prev => prev.map(d => d.id === newValue.id ? newValue : d));
     await debouncedUpdateDb(newValue);
   };
-  target.onUpdate.useSubscription({ projectId, flowStepId }, {
+  target.onUpdate.useSubscription({ projectId, flowId, flowStepId }, {
     onData: newData => setData(prev => prev.map(d => d.id === newData.id ? newData : d)),
   });
 
   const { mutateAsync: add } = target.add.useMutation();
-  target.onAdd.useSubscription({ projectId, flowStepId }, {
+  target.onAdd.useSubscription({ projectId, flowId, flowStepId }, {
     onData: newData => setData(prev => [...prev, newData]),
   });
   const { mutateAsync: remove } = target.remove.useMutation();
-  target.onRemove.useSubscription({ projectId, flowStepId }, {
+  target.onRemove.useSubscription({ projectId, flowId, flowStepId }, {
     onData: info => setData(prev => prev.filter(d => d.id !== info.id)),
   });
 

--- a/server/flow/flowStepColumnGroup.ts
+++ b/server/flow/flowStepColumnGroup.ts
@@ -9,7 +9,6 @@ import {
   flowStepColumnGroupSchema,
   Ids,
   ParentIds,
-  getFlowId,
 } from '../lib/flowStepColumnGroup';
 import mitt from 'mitt';
 import {
@@ -29,11 +28,13 @@ const ee = mitt<FlowStepColumnGroupEvents>();
 const idsSchema = flowStepColumnGroupSchema.pick({
   projectId: true,
   flowStepId: true,
+  flowId: true,
   id: true,
 });
 
 const parentIdsSchema = flowStepColumnGroupSchema.pick({
   projectId: true,
+  flowId: true,
   flowStepId: true,
 });
 
@@ -44,16 +45,11 @@ const filter = (data: ParentIds, input: ParentIds) => (
 
 /** flowStepColumnGroup の更新時、関連するfollowingColumnGroupsを更新します */
 const updateFollowingColumnGroups = async (data: Ids) => {
-  const flowId = await getFlowId(data);
-  if (flowId != null) {
-    tableFollowingColumnGroupsEventEmitter.emit(
-      'onUpdate', 
-      {
-        id: flowId,
-        projectId: data.projectId,
-      }
-    ); 
-  }
+  tableFollowingColumnGroupsEventEmitter.emit(
+    'onUpdate', {
+    id: data.flowId,
+    projectId: data.projectId,
+  }); 
 };
 
 // followingColumnGroups更新処理の呼び出しを、

--- a/server/lib/flowStepColumnGroup.ts
+++ b/server/lib/flowStepColumnGroup.ts
@@ -24,8 +24,8 @@ export const flowStepColumnGroupSchema = createSelectSchema(flowStepColumnGroups
     grouping: groupingSchema,
   });
 
-export type Ids = Pick<FlowStepColumnGroup, 'projectId'|'flowStepId'|'id'>;
-export type ParentIds = Pick<FlowStepColumnGroup, 'projectId'|'flowStepId'>;
+export type Ids = Pick<FlowStepColumnGroup, 'projectId'|'flowStepId'|'id'|'flowId'>;
+export type ParentIds = Pick<FlowStepColumnGroup, 'projectId'|'flowId'|'flowStepId'>;
 
 const whereIds = (ids: Ids) => {
   const { projectId, flowStepId, id } = ids;
@@ -83,14 +83,4 @@ export const add = async (params: Omit<FlowStepColumnGroup, 'id'>) => {
 
 export const remove = async (ids: Ids) =>
 await db.delete(flowStepColumnGroups).where(whereIds(ids));
-
-export const getFlowId = async (ids: Ids) => {
-  const data = await db.query.flowStepColumnGroups.findFirst({
-    where: whereIds(ids),
-    with: {
-      flowStep: true,
-    }
-  });
-  return data?.flowStep.flowId;
-};
 


### PR DESCRIPTION
followingColumnGroupsの更新処理について、flowStepColumnGroupが削除された際に、
どのflowに紐づけられていたflowStepColumnGroupを削除したのか情報スムーズに得られるよう、flowStepColumnGroupsにflowIdを追加し、各種サーバ側処理やフック引数を調整