### PR TITLE
tRPCコネクション数増加を抑える目的でシングルトンパターンを使用

### DIFF
--- a/next/src/lib/wsClient.ts
+++ b/next/src/lib/wsClient.ts
@@ -1,6 +1,14 @@
 import { createWSClient } from '@trpc/client';
 
-export const wsClient = createWSClient({
-  url: `ws://${process.env.NEXT_PUBLIC_SERVER_IP}:3001`,
-});
+type WSClient = ReturnType<typeof createWSClient>;
+let wsClient: WSClient | null = null;
+
+export const getWSClient = () => {
+  if (wsClient == null) {
+    wsClient = createWSClient({
+      url: `ws://${process.env.NEXT_PUBLIC_SERVER_IP}:3001`,
+    });
+  }
+  return wsClient;
+}
 

--- a/next/src/providers/TrpcProvider.tsx
+++ b/next/src/providers/TrpcProvider.tsx
@@ -1,37 +1,59 @@
 'use client'
 
-import React from 'react';
+import { ReactNode } from 'react';
 import type { AppRouter } from 'server/router';
 import { wsLink } from '@trpc/client';
-import { wsClient } from '@/lib/wsClient';
+import { getWSClient } from '@/lib/wsClient';
 import { 
   QueryClient,
   QueryClientProvider 
 } from '@tanstack/react-query';
+import { log } from '@/debug';
 import { createTRPCReact } from '@trpc/react-query';
 
 export const trpc = createTRPCReact<AppRouter>();
-
-const TrpcProvider: React.FC<
-  React.PropsWithChildren
-> = ({
-  children,
-}) => {
-
-  console.log('TrpcProvider rendered');
-
-  const [queryClient] = React.useState(() => new QueryClient());
-  const [trpcClient] = React.useState(() =>
-    trpc.createClient({
+let queryClient: QueryClient | null = null;
+const getQueryClient = () => {
+  if (queryClient == null) {
+    queryClient = new QueryClient();
+  }
+  return queryClient;
+};
+type TRPCClient = ReturnType<typeof trpc.createClient>;
+let trpcClient: TRPCClient | null = null;
+const getTrpcClient = () => {
+  if (trpcClient == null) {
+    trpcClient = trpc.createClient({
       links: [
-        wsLink({ client: wsClient }),
-      ],
-    })
-  );
+        wsLink({ client: getWSClient() }),
+      ]
+    });
+  }
+  return trpcClient;
+}
+
+export type TrpcProviderProps = {
+  children: ReactNode;
+}
+
+const TrpcProvider = ({
+  children,
+}: TrpcProviderProps) => {
+
+  log('TrpcProvider rendered');
+
+  //const [queryClient] = React.useState(() => new QueryClient());
+  //const [trpcClient] = React.useState(() =>
+  //  trpc.createClient({
+  //    links: [
+  //      wsLink({ client: wsClient }),
+  //    ],
+  //  })
+  //);
 
   return (
-    <QueryClientProvider client={queryClient}>
-      <trpc.Provider client={trpcClient} queryClient={queryClient}>
+    <QueryClientProvider client={getQueryClient()}>
+      <trpc.Provider client={getTrpcClient()} queryClient={getQueryClient()}>
         {children}
       </trpc.Provider>
     </QueryClientProvider>


### PR DESCRIPTION
サーバ側でカウントしている接続数の際限ない増加がなくなった。
それでも1クライアント当たり2接続で、もう少し調査が必要。